### PR TITLE
Fix vcpkg configuration

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
     "default-registry": {
             "kind": "git",
 	    "repository": "https://github.com/microsoft/vcpkg",
-	    "baseline": "326d8b43e365352ba3ccadf388d989082fe0f2a6"
+	    "baseline": "c150c1da644586fa6b34c5660860f472ac3c0d01"
 	},
     "registries": [
         {

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,4 +1,9 @@
 {
+    "default-registry": {
+            "kind": "git",
+	    "repository": "https://github.com/microsoft/vcpkg",
+	    "baseline": "326d8b43e365352ba3ccadf388d989082fe0f2a6"
+	},
     "registries": [
         {
             "kind": "git",


### PR DESCRIPTION
`vcpkg-configuration.json` has required `default-registry` to be set for the past year and a half (see [vcpkg/issues/29585](https://github.com/microsoft/vcpkg/issues/29585)). This isn't going to fix _every_ build error people have with this repo--you still need to manually set `VCPKG_ROOT` so cmake doesn't complain at you--but it _will_ fix project generation for people who know to do that.